### PR TITLE
add 'resolution' property in ColorPreprocessor

### DIFF
--- a/node_wrappers/color.py
+++ b/node_wrappers/color.py
@@ -5,7 +5,10 @@ class Color_Preprocessor:
     @classmethod
     def INPUT_TYPES(s):
         return {
-            "required": { "image": ("IMAGE",) }
+            "required": {
+                "image": ("IMAGE",),
+                "resolution": ("INT", {"default": 512, "min": 1, "max": 2048, "step": 1})
+                }
         }
 
     RETURN_TYPES = ("IMAGE",)
@@ -13,10 +16,10 @@ class Color_Preprocessor:
 
     CATEGORY = "ControlNet Preprocessors/T2IAdapter-only"
 
-    def execute(self, image, **kwargs):
+    def execute(self, image, resolution, **kwargs):
         from controlnet_aux.color import ColorDetector
 
-        return (common_annotator_call(ColorDetector(), image), )
+        return (common_annotator_call(ColorDetector(), image, detect_resolution=resolution), )
 
 
 


### PR DESCRIPTION

<img width="1019" alt="스크린샷 2023-09-01 오후 2 37 46" src="https://github.com/Fannovel16/comfyui_controlnet_aux/assets/16236663/bf94b245-4759-4bff-8368-b059d2513d71">
I found that current ColorPreprocessor can not adjust resolution like.
I think code is ready but it's not open yet so I connected. 
