### PR TITLE
fix #2

### DIFF
--- a/src/controlnet_aux/zoe/zoedepth/models/base_models/midas.py
+++ b/src/controlnet_aux/zoe/zoedepth/models/base_models/midas.py
@@ -173,7 +173,7 @@ class Resize(object):
 
     def __call__(self, x):
         width, height = self.get_size(*x.shape[-2:][::-1])
-        return nn.functional.interpolate(x, (height, width), mode='bilinear', align_corners=True)
+        return nn.functional.interpolate(x, (int(height), int(width)), mode='bilinear', align_corners=True)
 
 class PrepForMidas(object):
     def __init__(self, resize_mode="minimal", keep_aspect_ratio=True, img_size=384, do_resize=True):

--- a/src/custom_midas_repo/midas/backbones/beit.py
+++ b/src/custom_midas_repo/midas/backbones/beit.py
@@ -44,7 +44,7 @@ def _get_rel_pos_bias(self, window_size):
     old_sub_table = old_relative_position_bias_table[:old_num_relative_distance - 3]
 
     old_sub_table = old_sub_table.reshape(1, old_width, old_height, -1).permute(0, 3, 1, 2)
-    new_sub_table = F.interpolate(old_sub_table, size=(new_height, new_width), mode="bilinear")
+    new_sub_table = F.interpolate(old_sub_table, size=(int(new_height), int(new_width)), mode="bilinear")
     new_sub_table = new_sub_table.permute(0, 2, 3, 1).reshape(new_num_relative_distance - 3, -1)
 
     new_relative_position_bias_table = torch.cat(


### PR DESCRIPTION
numpy.int is now passed instead of a standard int.

This fix converts the numpy int to a standard int. Note that other modules might be affected and have to be patched in the same manner.