### PR TITLE
Add path judgment for config and change annotator_ckpts_path default value

### DIFF
--- a/src/controlnet_aux/anime_face_segment/__init__.py
+++ b/src/controlnet_aux/anime_face_segment/__init__.py
@@ -20,7 +20,7 @@ class AnimeFaceSegmentor:
         filename = filename or "UNet.pth"
         seg_filename = seg_filename or "isnetis.ckpt"
         model_path = custom_hf_download(pretrained_model_or_path, filename, subfolder="Annotators", cache_dir=cache_dir)
-        seg_model_path = custom_hf_download("skytnt/anime-seg", seg_filename)
+        seg_model_path = custom_hf_download("skytnt/anime-seg", seg_filename, cache_dir=cache_dir)
 
         model = UNet()
         ckpt = torch.load(model_path)

--- a/src/controlnet_aux/util.py
+++ b/src/controlnet_aux/util.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import warnings
 from huggingface_hub import hf_hub_download
 
-annotator_ckpts_path = os.path.join(os.path.dirname(__file__), 'ckpts')
+annotator_ckpts_path = os.path.join(Path(__file__).parents[2], 'ckpts')
 
 here = Path(__file__).parent.resolve()
 

--- a/utils.py
+++ b/utils.py
@@ -16,6 +16,12 @@ if os.path.exists(config_path):
 
     #annotator_ckpts_path = os.path.join(os.path.dirname(__file__), "ckpts")
     annotator_ckpts_path = str(Path(here, config["annotator_ckpts_path"]))
+    if not os.path.isdir(annotator_ckpts_path):
+        try:
+            os.makedirs(annotator_ckpts_path)
+        except:
+            log.error("Failed to create config ckpts directory")
+            annotator_ckpts_path = str(Path(here, "./ckpts"))
 else:
     annotator_ckpts_path = str(Path(here, "./ckpts"))
 


### PR DESCRIPTION
Add path judgment for config, and change the value of annotator_ckpts_path to .ckpts to be consistent with utils.py.
Now, models like `mobile_sam.pt` will no longer appear in folder ./src/controlnet_aux/ckpts/ and will download into ./ckpts/ like other models do.