### PR TITLE
Able to use symlinks or not via config.yaml and Fix SSL: CERTIFICATE_VERIFY_FAILED issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ wandb
 ckpts/
 
 test.ipynb
+config.yaml

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,6 @@
+# this is an example for config.yaml file, you can rename it to config.yaml if you want to use it
+# ###############################################################################################
+# you can also use absolute paths like: "/root/ComfyUI/custom_nodes/comfyui_controlnet_aux/ckpts" or "D:\\comfyui\\custom_nodes\\comfyui_controlnet_aux\\ckpts"
+annotator_ckpts_path: "./ckpts"
+# if you already have downloaded ckpts via huggingface hub into default cache path like: ~/.cache/huggingface/hub, you can set this True to use symlinks to save space
+USE_SYMLINKS: False

--- a/config.yaml
+++ b/config.yaml
@@ -1,1 +1,0 @@
-annotator_ckpts_path: "./ckpts"

--- a/src/controlnet_aux/util.py
+++ b/src/controlnet_aux/util.py
@@ -9,6 +9,22 @@ import warnings
 from huggingface_hub import hf_hub_download
 
 annotator_ckpts_path = os.path.join(Path(__file__).parents[2], 'ckpts')
+USE_SYMLINKS = False
+
+try:
+    USE_SYMLINKS = eval(os.environ['AUX_USE_SYMLINKS'])
+except:
+    warnings.warn("USE_SYMLINKS not set successfully. Using default value: False to download models.")
+    pass
+
+# fix SSL: CERTIFICATE_VERIFY_FAILED issue with pytorch download https://github.com/pytorch/pytorch/issues/33288
+try:
+    from torch.hub import load_state_dict_from_url
+    test_url = "https://download.pytorch.org/models/mobilenet_v2-b0353104.pth"
+    load_state_dict_from_url(test_url, progress=False)
+except:
+    import ssl
+    ssl._create_default_https_context = ssl._create_unverified_context
 
 here = Path(__file__).parent.resolve()
 
@@ -191,23 +207,52 @@ def ade_palette():
             [184, 255, 0], [0, 133, 255], [255, 214, 0], [25, 194, 194],
             [102, 255, 0], [92, 0, 255]]
 
-def custom_hf_download(pretrained_model_or_path, filename, cache_dir=annotator_ckpts_path, subfolder=''):
+def custom_hf_download(pretrained_model_or_path, filename, cache_dir=annotator_ckpts_path, subfolder='', use_symlinks=USE_SYMLINKS):
     local_dir = os.path.join(cache_dir, pretrained_model_or_path)
     model_path = os.path.join(local_dir, *subfolder.split('/'), filename)
+    
     if not os.path.exists(model_path):
-        cache_dir_d = os.path.join(cache_dir, pretrained_model_or_path, "cache")
+        if use_symlinks:
+            cache_dir_d = os.getenv("HUGGINGFACE_HUB_CACHE")
+            if cache_dir_d is None:
+                import platform
+                if platform.system() == "Windows":
+                    cache_dir_d = os.path.join(os.getenv("USERPROFILE"), ".cache", "huggingface", "hub")
+                else:
+                    cache_dir_d = os.path.join(os.getenv("HOME"), ".cache", "huggingface", "hub")
+            try:
+                # test_link
+                if not os.path.exists(cache_dir_d):
+                    os.makedirs(cache_dir_d)
+                open(os.path.join(cache_dir_d, f"linktest_{filename}.txt"), "w")
+                os.link(os.path.join(cache_dir_d, f"linktest_{filename}.txt"), os.path.join(cache_dir, f"linktest_{filename}.txt"))
+                os.remove(os.path.join(cache_dir, f"linktest_{filename}.txt"))
+                os.remove(os.path.join(cache_dir_d, f"linktest_{filename}.txt"))
+                print("Using symlinks to download models. \n",\
+                      "Make sure you have enough space on your cache folder. \n",\
+                      "And do not purge the cache folder after downloading.\n",\
+                      "Otherwise, you will have to re-download the models every time you run the script.\n",\
+                      "You can use USE_SYMLINKS: False in config.yaml to avoid this behavior.")
+            except:
+                print("Maybe not able to create symlink. Disable using symlinks.")
+                use_symlinks = False
+                cache_dir_d = os.path.join(cache_dir, pretrained_model_or_path, "cache")
+        else:
+            cache_dir_d = os.path.join(cache_dir, pretrained_model_or_path, "cache")
+
         model_path = hf_hub_download(repo_id=pretrained_model_or_path,
             cache_dir=cache_dir_d,
             local_dir=local_dir,
             subfolder=subfolder,
             filename=filename,
-            local_dir_use_symlinks=False,
+            local_dir_use_symlinks=use_symlinks,
             resume_download=True,
             etag_timeout=100
         )
-        try:
-            import shutil
-            shutil.rmtree(cache_dir_d)
-        except Exception as e :
-            print(e)
+        if not use_symlinks:
+            try:
+                import shutil
+                shutil.rmtree(cache_dir_d)
+            except Exception as e :
+                print(e)
     return model_path

--- a/utils.py
+++ b/utils.py
@@ -14,16 +14,26 @@ config_path = Path(here, "config.yaml")
 if os.path.exists(config_path):
     config = yaml.load(open(config_path, "r"), Loader=yaml.FullLoader)
 
-    #annotator_ckpts_path = os.path.join(os.path.dirname(__file__), "ckpts")
     annotator_ckpts_path = str(Path(here, config["annotator_ckpts_path"]))
+    USE_SYMLINKS = config["USE_SYMLINKS"]
+
+    if USE_SYMLINKS is None or type(USE_SYMLINKS) != bool:
+        log.error("USE_SYMLINKS must be a boolean. Using False by default.")
+        USE_SYMLINKS = False
+
     if not os.path.isdir(annotator_ckpts_path):
         try:
             os.makedirs(annotator_ckpts_path)
         except:
-            log.error("Failed to create config ckpts directory")
+            log.error("Failed to create config ckpts directory. Using default.")
             annotator_ckpts_path = str(Path(here, "./ckpts"))
 else:
     annotator_ckpts_path = str(Path(here, "./ckpts"))
+    USE_SYMLINKS = False
+
+os.environ['AUX_USE_SYMLINKS'] = str(USE_SYMLINKS)
+os.environ['AUX_ANNOTATOR_CKPTS_PATH'] = annotator_ckpts_path
+log.info(f"Using ckpts path: {annotator_ckpts_path}")
 
 MAX_RESOLUTION=2048 #Who the hell feed 4k images to ControlNet?
 HF_MODEL_NAME = "lllyasviel/Annotators"


### PR DESCRIPTION
rename config.yaml to config.example.yaml
fix [SSL: CERTIFICATE_VERIFY_FAILED while trying to download pretrained model #33288](https://github.com/pytorch/pytorch/issues/33288) while using pytorch pre-tarined models.
Able to use  symlinks or not via config.yaml.
Considering there might be a lot of unexpected situations using hard links on Windows systems. The default value is False