### PR TITLE
fix typo, yolo_nas_m.onnx should be yolox_m.onnx

### DIFF
--- a/node_wrappers/dwpose.py
+++ b/node_wrappers/dwpose.py
@@ -35,7 +35,7 @@ class DWPose_Preprocessor:
         input_types["optional"] = {
             **input_types["optional"],
             "bbox_detector": (
-                ["yolo_nas_l_fp16.onnx", "yolo_nas_m_fp16.onnx", "yolo_nas_s_fp16.onnx", "yolox_l.onnx", "yolo_nas_m.onnx", "yolox_s.onnx"], 
+                ["yolo_nas_l_fp16.onnx", "yolo_nas_m_fp16.onnx", "yolo_nas_s_fp16.onnx", "yolox_l.onnx", "yolox_m.onnx", "yolox_s.onnx"], 
                 {"default": "yolox_l.onnx"}
             ),
             "pose_estimator": (["dw-ll_ucoco_384.onnx", "dw-ll_ucoco.onnx", "dw-mm_ucoco.onnx", "dw-ss_ucoco.onnx"], {"default": "dw-ll_ucoco_384.onnx"})

--- a/node_wrappers/dwpose.py
+++ b/node_wrappers/dwpose.py
@@ -82,7 +82,7 @@ class AnimalPose_Preprocessor:
     def INPUT_TYPES(s):
         return create_node_input_types(
             bbox_detector = (
-                ["yolo_nas_l_fp16.onnx", "yolo_nas_m_fp16.onnx", "yolo_nas_s_fp16.onnx", "yolox_l.onnx", "yolo_nas_m.onnx", "yolox_s.onnx"], 
+                ["yolo_nas_l_fp16.onnx", "yolo_nas_m_fp16.onnx", "yolo_nas_s_fp16.onnx", "yolox_l.onnx", "yolox_m.onnx", "yolox_s.onnx"], 
                 {"default": "yolox_l.onnx"}
             ),
             pose_estimator = (["rtmpose-m_ap10k_256.onnx"], {"default": "rtmpose-m_ap10k_256.onnx"})


### PR DESCRIPTION
There is no model named yolo_nas_m.onnx in [hr16/yolo-nas-fp16](https://huggingface.co/hr16/yolo-nas-fp16) or [hr16/yolox-onnx](https://huggingface.co/hr16/yolox-onnx). I think it's a typo.