### PR TITLE
fix numpy convert issue while using --only-gpu argument

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -64,7 +64,7 @@ def common_annotator_call(model, tensor_image, input_batch=False, **kwargs):
 
     out_list = []
     for image in tensor_image:
-        np_image = np.asarray(image * 255., dtype=np.uint8)
+        np_image = np.asarray(image.cpu() * 255., dtype=np.uint8)
         np_result = model(np_image, output_type="np", detect_resolution=detect_resolution, **kwargs)
         out_list.append(torch.from_numpy(np_result.astype(np.float32) / 255.0))
     return torch.stack(out_list, dim=0)


### PR DESCRIPTION
If you run ComfyUI with the **--only-gpu** argument and use the controlnet preprocessor after **VAE decoder** node, the following error will occur: `TypeError: can‘t convert cuda:0 device type tensor to numpy. ` 
Here is my workflow:
![workflow](https://github.com/Fannovel16/comfyui_controlnet_aux/assets/140777998/444bafa8-bb60-47c6-ab6b-f64cd390b82c)

And Error:
![2E64C43D8D1675C06A33C9A531E56647](https://github.com/Fannovel16/comfyui_controlnet_aux/assets/140777998/9ec8ca89-7db9-4a11-9fed-af72f5d0e437)
