### PR TITLE
fix XDoG Preprocessor threshold

### DIFF
--- a/node_wrappers/scribble.py
+++ b/node_wrappers/scribble.py
@@ -29,11 +29,11 @@ class Scribble_XDoG_Preprocessor:
 
     CATEGORY = "ControlNet Preprocessors/Line Extractors"
 
-    def execute(self, image, resolution=512, **kwargs):
+    def execute(self, image, threshold, resolution=512, **kwargs):
         from controlnet_aux.scribble import ScribbleXDog_Detector
 
         model = ScribbleXDog_Detector()
-        return (common_annotator_call(model, image, resolution=resolution), )
+        return (common_annotator_call(model, image, resolution=resolution, thr_a=threshold), )
 
 NODE_CLASS_MAPPINGS = {
     "ScribblePreprocessor": Scribble_Preprocessor,


### PR DESCRIPTION
This fixes the threshold parameter, which currently does nothing.

This is just a quick fix, I didn't spend time diving into your code nor getting familiar with the ComfyUI API, so please review accordingly.

In particular, I'm surprised that `ScribbleXDog_Detector`'s `detect_resolution` parameter is passed with name `resolution` by this caller... yet it works, and doesn't if renamed.