### PR TITLE
Fix scaling in FacialPartColoringFromPoseKps

### DIFF
--- a/node_wrappers/pose_keypoint_postprocess.py
+++ b/node_wrappers/pose_keypoint_postprocess.py
@@ -107,9 +107,11 @@ class FacialPartColoringFromPoseKps:
         return (torch.from_numpy(np_frames).float() / 255.,)
             
     def draw_kps(self, pose_frame, mode, **facial_part_colors):
-        canvas = np.zeros((pose_frame["canvas_height"], pose_frame["canvas_width"], 3), dtype=np.uint8)
-        for (person, part_name) in itertools.product(pose_frame["people"], FACIAL_PARTS):
-            facial_kps = rearrange(np.array(person['face_keypoints_2d']), "(n c) -> n c", n=70, c=3)[:, :2]
+        width, height = pose_frame["canvas_width"], pose_frame["canvas_height"]
+        canvas = np.zeros((height, width, 3), dtype=np.uint8)
+        for person, part_name in itertools.product(pose_frame["people"], FACIAL_PARTS):
+            n = len(person["face_keypoints_2d"]) // 3
+            facial_kps = rearrange(np.array(person["face_keypoints_2d"]), "(n c) -> n c", n=n, c=3)[:, :2] * (width, height)
             facial_kps = facial_kps.astype(np.int32)
             part_color = ImageColor.getrgb(facial_part_colors[part_name])[:3]
             if mode == "circle":


### PR DESCRIPTION
Solving two problems I encountered:
1. `person['face_keypoints_2d']` would appear as a 213 element long list, and would fail when trying to be reshaped into 70 by 3. I hypothesized it was just an extra element getting added somehow, so I updated `n` so it can dynamically adjust. Can't reproduce so I'm not sure exactly what was going on.
2. `person["face_keypoints_2d"]` is full of floats from between 0 and 1 and need to be scaled based on the image size. The resizing originally occurs here:

https://github.com/Fannovel16/comfyui_controlnet_aux/tree/main/src/controlnet_aux/open_pose/__init__.py#L205


