### PR TITLE
Add custom_torch_hub_download for#255

### DIFF
--- a/src/controlnet_aux/anime_face_segment/network.py
+++ b/src/controlnet_aux/anime_face_segment/network.py
@@ -3,14 +3,16 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torchvision
-from torchvision.models import MobileNet_V2_Weights
+
+from controlnet_aux.util import custom_torch_download
 
 class UNet(nn.Module):
     def __init__(self):
         super(UNet, self).__init__()
         self.NUM_SEG_CLASSES = 7 # Background, hair, face, eye, mouth, skin, clothes
-        
-        mobilenet_v2 = torchvision.models.mobilenet_v2(weights=MobileNet_V2_Weights.IMAGENET1K_V1)
+
+        mobilenet_v2 = torchvision.models.mobilenet_v2(pretrained=False)
+        mobilenet_v2.load_state_dict(torch.load(custom_torch_download(filename="mobilenet_v2-b0353104.pth")), strict=True)
         mob_blocks = mobilenet_v2.features
         
         # Encoder

--- a/src/controlnet_aux/diffusion_edge/denoising_diffusion_pytorch/mask_cond_unet.py
+++ b/src/controlnet_aux/diffusion_edge/denoising_diffusion_pytorch/mask_cond_unet.py
@@ -9,6 +9,8 @@ from controlnet_aux.diffusion_edge.denoising_diffusion_pytorch.efficientnet impo
 from controlnet_aux.diffusion_edge.denoising_diffusion_pytorch.resnet import resnet101, ResNet101_Weights
 from controlnet_aux.diffusion_edge.denoising_diffusion_pytorch.swin_transformer import swin_b, Swin_B_Weights
 from controlnet_aux.diffusion_edge.denoising_diffusion_pytorch.vgg import vgg16, VGG16_Weights
+
+from controlnet_aux.util import custom_torch_download
 # from controlnet_aux.diffusion_edge.denoising_diffusion_pytorch.wcc import fft
 ### Compared to unet4:
 # 1. add FFT-Conv on the mid feature.
@@ -697,7 +699,9 @@ class Unet(nn.Module):
             if cfg.get('without_pretrain', False):
                 self.init_conv_mask = swin_b()
             else:
-                self.init_conv_mask = swin_b(weights=Swin_B_Weights)
+                swin_b_model = swin_b(pretrained=False)
+                swin_b_model.load_state_dict(torch.load(custom_torch_download(filename="swin_b-68c6b09e.pth")), strict=False)
+                self.init_conv_mask = swin_b_model
         elif cfg.cond_net == 'vgg':
             f_condnet = 128
             if cfg.get('without_pretrain', False):

--- a/src/controlnet_aux/diffusion_edge/taming/modules/losses/lpips.py
+++ b/src/controlnet_aux/diffusion_edge/taming/modules/losses/lpips.py
@@ -7,13 +7,15 @@ from collections import namedtuple
 
 from .util import get_ckpt_path
 
+from controlnet_aux.util import custom_torch_download
+
 class LPIPS(nn.Module):
     # Learned perceptual metric
     def __init__(self, use_dropout=True):
         super().__init__()
         self.scaling_layer = ScalingLayer()
         self.chns = [64, 128, 256, 512, 512]  # vg16 features
-        self.net = vgg16(pretrained=True, requires_grad=False)
+        self.net = vgg16(pretrained=False, requires_grad=False)
         self.lin0 = NetLinLayer(self.chns[0], use_dropout=use_dropout)
         self.lin1 = NetLinLayer(self.chns[1], use_dropout=use_dropout)
         self.lin2 = NetLinLayer(self.chns[2], use_dropout=use_dropout)
@@ -73,9 +75,11 @@ class NetLinLayer(nn.Module):
 
 
 class vgg16(torch.nn.Module):
-    def __init__(self, requires_grad=False, pretrained=True):
+    def __init__(self, requires_grad=False, pretrained=False):
         super(vgg16, self).__init__()
-        vgg_pretrained_features = models.vgg16(pretrained=pretrained).features
+        vgg16_model = models.vgg16(pretrained=pretrained)
+        vgg16_model.load_state_dict(torch.load(custom_torch_download(filename="vgg16-397923af.pth")), strict=True)
+        vgg_pretrained_features = vgg16_model.features
         self.slice1 = torch.nn.Sequential()
         self.slice2 = torch.nn.Sequential()
         self.slice3 = torch.nn.Sequential()

--- a/src/controlnet_aux/util.py
+++ b/src/controlnet_aux/util.py
@@ -220,11 +220,12 @@ def ade_palette():
             [184, 255, 0], [0, 133, 255], [255, 214, 0], [25, 194, 194],
             [102, 255, 0], [92, 0, 255]]
 
+#https://stackoverflow.com/a/55542529
 def check_hash_from_torch_hub(file_path, filename):
     from hashlib import sha256
     h = sha256()
     basename, _ = filename.split('.')
-    _, orig_hash = basename.split('-')
+    _, ref_hash = basename.split('-')
     with open(file_path, 'rb') as file:
         while True:
             # Reading is buffered, so we can read smaller chunks.
@@ -234,7 +235,7 @@ def check_hash_from_torch_hub(file_path, filename):
             h.update(chunk)
 
     curr_hash = h.hexdigest()
-    return curr_hash[:len(orig_hash)] == orig_hash
+    return curr_hash[:len(ref_hash)] == ref_hash
 
 def custom_torch_download(filename, cache_dir=annotator_ckpts_path):
     local_dir = os.path.join(get_dir(), 'checkpoints')

--- a/src/controlnet_aux/util.py
+++ b/src/controlnet_aux/util.py
@@ -220,21 +220,22 @@ def ade_palette():
             [184, 255, 0], [0, 133, 255], [255, 214, 0], [25, 194, 194],
             [102, 255, 0], [92, 0, 255]]
 
-#https://stackoverflow.com/a/55542529
+#https://stackoverflow.com/a/44873382
+#Assume that the minimum version of Python ppl use is 3.9
+def sha256sum(file_path):
+    import hashlib
+    h  = hashlib.sha256()
+    b  = bytearray(128*1024)
+    mv = memoryview(b)
+    with open(file_path, 'rb', buffering=0) as f:
+        while n := f.readinto(mv):
+            h.update(mv[:n])
+    return h.hexdigest()
+
 def check_hash_from_torch_hub(file_path, filename):
-    from hashlib import sha256
-    h = sha256()
     basename, _ = filename.split('.')
     _, ref_hash = basename.split('-')
-    with open(file_path, 'rb') as file:
-        while True:
-            # Reading is buffered, so we can read smaller chunks.
-            chunk = file.read(h.block_size)
-            if not chunk:
-                break
-            h.update(chunk)
-
-    curr_hash = h.hexdigest()
+    curr_hash = sha256sum(file_path)
     return curr_hash[:len(ref_hash)] == ref_hash
 
 def custom_torch_download(filename, cache_dir=annotator_ckpts_path):

--- a/src/controlnet_aux/util.py
+++ b/src/controlnet_aux/util.py
@@ -6,6 +6,7 @@ import numpy as np
 import torch
 from pathlib import Path
 import warnings
+from torch.hub import get_dir, download_url_to_file
 from huggingface_hub import hf_hub_download
 
 TORCHHUB_PATH = Path(__file__).parent / 'depth_anything' / 'torchhub'
@@ -217,6 +218,29 @@ def ade_palette():
             [71, 0, 255], [122, 0, 255], [0, 255, 184], [0, 92, 255],
             [184, 255, 0], [0, 133, 255], [255, 214, 0], [25, 194, 194],
             [102, 255, 0], [92, 0, 255]]
+
+def custom_torch_download(filename, cache_dir=annotator_ckpts_path):
+    local_dir = os.path.join(get_dir(), 'checkpoints')
+    model_path = os.path.join(local_dir, filename)
+
+    if not os.path.exists(model_path):
+        local_dir = os.path.join(cache_dir, "torch")
+        if not os.path.exists(local_dir):
+            os.mkdir(local_dir)
+
+        model_path = os.path.join(local_dir, filename)
+
+        if not os.path.exists(model_path):
+
+            model_url = "https://download.pytorch.org/models/"+filename
+            try:
+                download_url_to_file(url = model_url, dst = model_path)
+            except:
+                warnings.warn("ssl verify failed, try use http instead.")
+                model_url = "http://download.pytorch.org/models/"+filename
+                download_url_to_file(url = model_url, dst = model_path)
+
+    return model_path
 
 def custom_hf_download(pretrained_model_or_path, filename, cache_dir=annotator_ckpts_path, subfolder='', use_symlinks=USE_SYMLINKS, repo_type="model"):
     local_dir = os.path.join(cache_dir, pretrained_model_or_path)


### PR DESCRIPTION
Now these three models will download in the `/ckpts/torch/` folder if they don't exist in ` .cache/torch/hub/checkpoints/`. So they won't be cleaned by certain cases. 

![custom_torch_download](https://github.com/Fannovel16/comfyui_controlnet_aux/assets/140777998/ace8e0ec-61da-4511-8cd9-40ac81aa6dd9)

I test all the nodes by this workflow. I think these three are all torch hub models.
![aux_for_all](https://github.com/Fannovel16/comfyui_controlnet_aux/assets/140777998/4afb8878-f793-4e98-af5a-74a2680731bf)
