### PR TITLE
Fix custom model path, add custom temp path. Fix(Fannovel16#264)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,7 +1,7 @@
 # this is an example for config.yaml file, you can rename it to config.yaml if you want to use it
 # ###############################################################################################
 # This path is for custom pressesor models base folder. default is "./ckpts"
-# you can also use absolute paths like: "/root/ComfyUI/custom_nodes/comfyui_controlnet_aux/ckpts" or "D:\\comfyui\\custom_nodes\\comfyui_controlnet_aux\\ckpts"
+# you can also use absolute paths like: "/root/ComfyUI/custom_nodes/comfyui_controlnet_aux/ckpts" or "D:\\ComfyUI\\custom_nodes\\comfyui_controlnet_aux\\ckpts"
 annotator_ckpts_path: "./ckpts"
 # ###############################################################################################
 # This path is for downloading temporary files.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,7 +1,12 @@
 # this is an example for config.yaml file, you can rename it to config.yaml if you want to use it
 # ###############################################################################################
+# This path is for custom pressesor models base folder. default is "./ckpts"
 # you can also use absolute paths like: "/root/ComfyUI/custom_nodes/comfyui_controlnet_aux/ckpts" or "D:\\comfyui\\custom_nodes\\comfyui_controlnet_aux\\ckpts"
 annotator_ckpts_path: "./ckpts"
+# ###############################################################################################
+# This path is for downloading temporary files.
+# You SHOULD use absolute path for this like"D:\\temp", DO NOT use relative paths. None for default.
+custom_temp_path: None
 # ###############################################################################################
 # if you already have downloaded ckpts via huggingface hub into default cache path like: ~/.cache/huggingface/hub, you can set this True to use symlinks to save space
 USE_SYMLINKS: False

--- a/src/controlnet_aux/util.py
+++ b/src/controlnet_aux/util.py
@@ -38,6 +38,15 @@ except:
     warnings.warn("USE_SYMLINKS not set successfully. Using default value: False to download models.")
     pass
 
+try:
+    temp_dir = os.environ['AUX_TEMP_DIR']
+    if len(temp_dir) >= 60:
+        warnings.warn(f"custom temp dir is too long. Using default")
+        temp_dir = tempfile.gettempdir()
+except:
+    warnings.warn(f"custom temp dir not set successfully")
+    pass
+
 here = Path(__file__).parent.resolve()
 
 def HWC3(x):
@@ -240,12 +249,12 @@ def check_hash_from_torch_hub(file_path, filename):
     curr_hash = sha256sum(file_path)
     return curr_hash[:len(ref_hash)] == ref_hash
 
-def custom_torch_download(filename, cache_dir=annotator_ckpts_path):
+def custom_torch_download(filename, ckpts_dir=annotator_ckpts_path):
     local_dir = os.path.join(get_dir(), 'checkpoints')
     model_path = os.path.join(local_dir, filename)
 
     if not os.path.exists(model_path):
-        local_dir = os.path.join(cache_dir, "torch")
+        local_dir = os.path.join(ckpts_dir, "torch")
         if not os.path.exists(local_dir):
             os.mkdir(local_dir)
 
@@ -260,13 +269,19 @@ def custom_torch_download(filename, cache_dir=annotator_ckpts_path):
                 download_url_to_file(url = model_url, dst = model_path)
                 assert check_hash_from_torch_hub(model_path, filename), f"Hash check failed as file {filename} is corrupted"
                 print("Hash check passed")
+    
+    print(f"model_path is {model_path}")
     return model_path
 
-def custom_hf_download(pretrained_model_or_path, filename, cache_dir=temp_dir, subfolder='', use_symlinks=USE_SYMLINKS, repo_type="model"):
-    if use_symlinks:
-        cache_dir = annotator_ckpts_path
-    local_dir = os.path.join(cache_dir, pretrained_model_or_path)
+def custom_hf_download(pretrained_model_or_path, filename, cache_dir=temp_dir, ckpts_dir=annotator_ckpts_path, subfolder='', use_symlinks=USE_SYMLINKS, repo_type="model"):
+    
+    print(f"cacher folder is {cache_dir}, you can set it by custom_tmp_path in config.yaml")
+
+    local_dir = os.path.join(ckpts_dir, pretrained_model_or_path)
     model_path = os.path.join(local_dir, *subfolder.split('/'), filename)
+
+    if len(str(model_path)) >= 255:
+        warnings.warn(f"Path {model_path} is too long, \n please change annotator_ckpts_path in config.yaml")
     
     if not os.path.exists(model_path):
         print(f"Failed to find {model_path}.\n Downloading from huggingface.co")
@@ -283,8 +298,8 @@ def custom_hf_download(pretrained_model_or_path, filename, cache_dir=temp_dir, s
                 if not os.path.exists(cache_dir_d):
                     os.makedirs(cache_dir_d)
                 open(os.path.join(cache_dir_d, f"linktest_{filename}.txt"), "w")
-                os.link(os.path.join(cache_dir_d, f"linktest_{filename}.txt"), os.path.join(cache_dir, f"linktest_{filename}.txt"))
-                os.remove(os.path.join(cache_dir, f"linktest_{filename}.txt"))
+                os.link(os.path.join(cache_dir_d, f"linktest_{filename}.txt"), os.path.join(ckpts_dir, f"linktest_{filename}.txt"))
+                os.remove(os.path.join(ckpts_dir, f"linktest_{filename}.txt"))
                 os.remove(os.path.join(cache_dir_d, f"linktest_{filename}.txt"))
                 print("Using symlinks to download models. \n",\
                       "Make sure you have enough space on your cache folder. \n",\
@@ -294,9 +309,9 @@ def custom_hf_download(pretrained_model_or_path, filename, cache_dir=temp_dir, s
             except:
                 print("Maybe not able to create symlink. Disable using symlinks.")
                 use_symlinks = False
-                cache_dir_d = os.path.join(cache_dir, pretrained_model_or_path, "cache")
+                cache_dir_d = os.path.join(cache_dir, "aux", pretrained_model_or_path)
         else:
-            cache_dir_d = os.path.join(cache_dir, pretrained_model_or_path, "cache")
+            cache_dir_d = os.path.join(cache_dir, "aux", pretrained_model_or_path)
 
         model_path = hf_hub_download(repo_id=pretrained_model_or_path,
             cache_dir=cache_dir_d,
@@ -314,5 +329,7 @@ def custom_hf_download(pretrained_model_or_path, filename, cache_dir=temp_dir, s
                 shutil.rmtree(cache_dir_d)
             except Exception as e :
                 print(e)
-        
+
+    print(f"model_path is {model_path}")
+
     return model_path


### PR DESCRIPTION
![image](https://github.com/Fannovel16/comfyui_controlnet_aux/assets/140777998/5b411351-abe2-4197-bd7f-3ab94bebed4c)
We can save models in **Disk O** with downloading temp in **Disk D** while ComfyUI folder in **Disk I** with config.yaml now.  

We don't need to move the default ckpts path, because the logget model path is` LiheYoung\Depth-Anything\checkpoints_metric_depth\depth_anything_metric_depth_outdoor.pt` which takes 88 characters. and  `F:\ComfyUI_windows_portable_nvidia_cu121_or_cpu\ComfyUI_windows_portable\ComfyUI\custom_nodes\comfyui_controlnet_aux\ckpts` takes 122 characters, so we still have 45 characters left.
This may not enought for people who use symlinks in this folder, because the filename will take 64 characters.
![image](https://github.com/Fannovel16/comfyui_controlnet_aux/assets/140777998/44c0c4fd-c67a-4def-976a-bb812d58de30)
But symlinks is usually used for linking to an existing cache in the huggingface hub folder, I don't think this would be a problem.