### PR TITLE
Update util.py - Fix windows issue "AUX" is special name.

### DIFF
--- a/src/controlnet_aux/util.py
+++ b/src/controlnet_aux/util.py
@@ -309,9 +309,9 @@ def custom_hf_download(pretrained_model_or_path, filename, cache_dir=temp_dir, c
             except:
                 print("Maybe not able to create symlink. Disable using symlinks.")
                 use_symlinks = False
-                cache_dir_d = os.path.join(cache_dir, "aux", pretrained_model_or_path)
+                cache_dir_d = os.path.join(cache_dir, "aux_temp", pretrained_model_or_path)
         else:
-            cache_dir_d = os.path.join(cache_dir, "aux", pretrained_model_or_path)
+            cache_dir_d = os.path.join(cache_dir, "aux_temp", pretrained_model_or_path)
 
         model_path = hf_hub_download(repo_id=pretrained_model_or_path,
             cache_dir=cache_dir_d,


### PR DESCRIPTION
Hi,  The DWPose Estimator node couldn't run because the directory name was identified as "AUX". It cannot be run in windows.

https://stackoverflow.com/questions/40794287/cannot-write-to-any-path-with-filename-aux

> Do not use the following reserved names for the name of a file: CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9. Also avoid these names followed immediately by an extension; for example, NUL.txt is not recommended.