### PR TITLE
add edge-drawing parameter-free (EDPF) preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Install [ComfyUI Manager](https://github.com/ltdrdata/ComfyUI-Manager) and do st
 ## Alternative:
 If you're running on Linux, or non-admin account on windows you'll want to ensure `/ComfyUI/custom_nodes` and `comfyui_controlnet_aux` has write permissions.
 
-There is now a **install.bat** you can run to install to portable if detected. Otherwise it will default to system and assume you followed ConfyUI's manual installation steps. 
+There is now a **install.bat** you can run to install to portable if detected. Otherwise it will default to system and assume you followed ConfyUI's manual installation steps.
 
 If you can't run **install.bat** (e.g. you are a Linux user). Open the CMD/Shell and do the following:
   - Navigate to your `/ComfyUI/custom_nodes/` folder
@@ -37,7 +37,7 @@ If you can't run **install.bat** (e.g. you are a Linux user). Open the CMD/Shell
 
 # Nodes
 Please note that this repo only supports preprocessors making hint images (e.g. stickman, canny edge, etc).
-All preprocessors except Inpaint are intergrated into `AIO Aux Preprocessor` node. 
+All preprocessors except Inpaint are intergrated into `AIO Aux Preprocessor` node.
 This node allow you to quickly get the preprocessor but a preprocessor's own threshold parameters won't be able to set.
 You need to use its node directly to set thresholds.
 
@@ -60,6 +60,7 @@ You need to use its node directly to set thresholds.
 | TEED Soft-Edge Lines        | teed                      | [controlnet-sd-xl-1.0-softedge-dexined](https://huggingface.co/SargeZT/controlnet-sd-xl-1.0-softedge-dexined/blob/main/controlnet-sd-xl-1.0-softedge-dexined.safetensors) <br> control_v11p_sd15_softedge (Theoretically)
 | Scribble PiDiNet Lines      | scribble_pidinet          | control_v11p_sd15_scribble <br> control_scribble |
 | AnyLine Lineart             |                           | mistoLine_fp16.safetensors <br> mistoLine_rank256 <br> control_v11p_sd15s2_lineart_anime <br> control_v11p_sd15_lineart |
+| Edge-Drawing Parameter-Free | -                         | [controlnetMyseeEdgeDrawing](https://civitai.com/models/149740) |
 
 ## Normal and Depth Estimators
 | Preprocessor Node           | sd-webui-controlnet/other |          ControlNet/T2I-Adapter           |
@@ -81,7 +82,7 @@ You need to use its node directly to set thresholds.
 |-----------------------------|---------------------------|-------------------------------------------|
 | DWPose Estimator                 | dw_openpose_full          | control_v11p_sd15_openpose <br> control_openpose <br> t2iadapter_openpose |
 | OpenPose Estimator               | openpose (detect_body) <br> openpose_hand (detect_body + detect_hand) <br> openpose_faceonly (detect_face) <br> openpose_full (detect_hand + detect_body + detect_face)    | control_v11p_sd15_openpose <br> control_openpose <br> t2iadapter_openpose |
-| MediaPipe Face Mesh         | mediapipe_face            | controlnet_sd21_laion_face_v2             | 
+| MediaPipe Face Mesh         | mediapipe_face            | controlnet_sd21_laion_face_v2             |
 | Animal Estimator                 | animal_openpose           | [control_sd15_animal_openpose_fp16](https://huggingface.co/huchenlei/animal_openpose/blob/main/control_sd15_animal_openpose_fp16.pth) |
 
 ## Optical Flow Estimators
@@ -248,7 +249,7 @@ https://github.com/Fannovel16/comfyui_controlnet_aux/blob/master/tests/test_cn_a
 This repo has a new mechanism which will skip any custom node can't be imported. If you meet this case, please create a issue on [Issues tab](https://github.com/Fannovel16/comfyui_controlnet_aux/issues) with the log from the command line.
 
 ## DWPose/AnimalPose only uses CPU so it's so slow. How can I make it use GPU?
-There are two ways to speed-up DWPose: using TorchScript checkpoints (.torchscript.pt) checkpoints or ONNXRuntime (.onnx). TorchScript way is little bit slower than ONNXRuntime but doesn't require any additional library and still way way faster than CPU. 
+There are two ways to speed-up DWPose: using TorchScript checkpoints (.torchscript.pt) checkpoints or ONNXRuntime (.onnx). TorchScript way is little bit slower than ONNXRuntime but doesn't require any additional library and still way way faster than CPU.
 
 A torchscript bbox detector is compatiable with an onnx pose estimator and vice versa.
 ### TorchScript
@@ -274,7 +275,7 @@ Note that if this is your first time using ComfyUI, please test if it can run on
 # Assets files of preprocessors
 * anime_face_segment:  [bdsqlsz/qinglong_controlnet-lllite/Annotators/UNet.pth](https://huggingface.co/bdsqlsz/qinglong_controlnet-lllite/blob/main/Annotators/UNet.pth), [anime-seg/isnetis.ckpt](https://huggingface.co/skytnt/anime-seg/blob/main/isnetis.ckpt)
 * densepose:  [LayerNorm/DensePose-TorchScript-with-hint-image/densepose_r50_fpn_dl.torchscript](https://huggingface.co/LayerNorm/DensePose-TorchScript-with-hint-image/blob/main/densepose_r50_fpn_dl.torchscript)
-* dwpose:  
+* dwpose:
 * * bbox_detector: Either [yzd-v/DWPose/yolox_l.onnx](https://huggingface.co/yzd-v/DWPose/blob/main/yolox_l.onnx), [hr16/yolox-onnx/yolox_l.torchscript.pt](https://huggingface.co/hr16/yolox-onnx/blob/main/yolox_l.torchscript.pt), [hr16/yolo-nas-fp16/yolo_nas_l_fp16.onnx](https://huggingface.co/hr16/yolo-nas-fp16/blob/main/yolo_nas_l_fp16.onnx), [hr16/yolo-nas-fp16/yolo_nas_m_fp16.onnx](https://huggingface.co/hr16/yolo-nas-fp16/blob/main/yolo_nas_m_fp16.onnx), [hr16/yolo-nas-fp16/yolo_nas_s_fp16.onnx](https://huggingface.co/hr16/yolo-nas-fp16/blob/main/yolo_nas_s_fp16.onnx)
 * * pose_estimator: Either [hr16/DWPose-TorchScript-BatchSize5/dw-ll_ucoco_384_bs5.torchscript.pt](https://huggingface.co/hr16/DWPose-TorchScript-BatchSize5/blob/main/dw-ll_ucoco_384_bs5.torchscript.pt), [yzd-v/DWPose/dw-ll_ucoco_384.onnx](https://huggingface.co/yzd-v/DWPose/blob/main/dw-ll_ucoco_384.onnx)
 * animal_pose (ap10k):

--- a/node_wrappers/edpf.py
+++ b/node_wrappers/edpf.py
@@ -1,0 +1,25 @@
+from ..utils import common_annotator_call, create_node_input_types, run_script
+import comfy.model_management as model_management
+
+class EDPF_Preprocessor:
+    @classmethod
+    def INPUT_TYPES(s):
+        return create_node_input_types()
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "execute"
+
+    CATEGORY = "ControlNet Preprocessors/Line Extractors"
+
+    def execute(self, image, resolution=512, **kwargs):
+        from controlnet_aux.edpf import EDPF
+        return (common_annotator_call(EDPF(), image, resolution=resolution), )
+
+
+
+NODE_CLASS_MAPPINGS = {
+    "EDPFPreprocessor": EDPF_Preprocessor
+}
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "EDPFPreprocessor": "Edge-Drawing Parameter-Free (EDPF)"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ yacs
 trimesh[easy]
 albumentations
 scikit-learn
+opencv-contrib-python-headless>=4.7.0.72 # IMPORTANT: this needs to be last

--- a/src/controlnet_aux/edpf/__init__.py
+++ b/src/controlnet_aux/edpf/__init__.py
@@ -1,0 +1,23 @@
+import warnings
+import cv2
+import numpy as np
+from PIL import Image
+from controlnet_aux.util import resize_image_with_pad, common_input_validate, HWC3
+
+class EDPF:
+    def __call__(self, input_image=None, detect_resolution=512, output_type=None, upscale_method="INTER_CUBIC", **kwargs):
+        input_image, output_type = common_input_validate(input_image, output_type, **kwargs)
+        detected_map, remove_pad = resize_image_with_pad(input_image, detect_resolution, upscale_method)
+
+        ed = cv2.ximgproc.createEdgeDrawing()
+        params = cv2.ximgproc.EdgeDrawing.Params()
+        params.PFmode = True
+        ed.setParams(params)
+        edges = ed.detectEdges(cv2.cvtColor(detected_map, cv2.COLOR_BGR2GRAY))
+        detected_map = ed.getEdgeImage(edges)
+        detected_map = HWC3(remove_pad(detected_map))
+
+        if output_type == "pil":
+            detected_map = Image.fromarray(detected_map)
+
+        return detected_map

--- a/src/controlnet_aux/processor.py
+++ b/src/controlnet_aux/processor.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional, Union
 
 from PIL import Image
 
-from controlnet_aux import (CannyDetector, ContentShuffleDetector, HEDdetector,
+from controlnet_aux import (CannyDetector, EdgeDrawing, ContentShuffleDetector, HEDdetector,
                             LeresDetector, LineartAnimeDetector,
                             LineartDetector, MediapipeFaceDetector,
                             MidasDetector, MLSDdetector, NormalBaeDetector,
@@ -37,13 +37,14 @@ MODELS = {
     'lineart_coarse': {'class': LineartDetector, 'checkpoint': True},
     'lineart_realistic': {'class': LineartDetector, 'checkpoint': True},
     'lineart_anime': {'class': LineartAnimeDetector, 'checkpoint': True},
-    'depth_zoe': {'class': ZoeDetector, 'checkpoint': True}, 
-    'depth_leres': {'class': LeresDetector, 'checkpoint': True}, 
-    'depth_leres++': {'class': LeresDetector, 'checkpoint': True}, 
+    'depth_zoe': {'class': ZoeDetector, 'checkpoint': True},
+    'depth_leres': {'class': LeresDetector, 'checkpoint': True},
+    'depth_leres++': {'class': LeresDetector, 'checkpoint': True},
     # instantiate
     'shuffle': {'class': ContentShuffleDetector, 'checkpoint': False},
     'mediapipe_face': {'class': MediapipeFaceDetector, 'checkpoint': False},
     'canny': {'class': CannyDetector, 'checkpoint': False},
+    'edpf': {'class': EdgeDrawing, 'checkpoint': False},
     'tile': {'class': TileDetector, 'checkpoint': False},
 }
 
@@ -69,6 +70,7 @@ MODEL_PARAMS = {
     'lineart_coarse': {'coarse': True},
     'lineart_anime': {},
     'canny': {},
+    'edpf': {},
     'shuffle': {},
     'depth_zoe': {},
     'depth_leres': {'boost': False},
@@ -87,7 +89,7 @@ class Processor:
         Args:
             processor_id (str): processor name, options are 'hed, midas, mlsd, openpose,
                                 pidinet, normalbae, lineart, lineart_coarse, lineart_anime,
-                                canny, content_shuffle, zoe, mediapipe_face, tile'
+                                canny, edpf, content_shuffle, zoe, mediapipe_face, tile'
             params (Optional[Dict]): parameters for the processor
         """
         LOGGER.info("Loading %s".format(processor_id))

--- a/src/controlnet_aux/tests/test_processor.py
+++ b/src/controlnet_aux/tests/test_processor.py
@@ -66,6 +66,12 @@ class TestProcessor(unittest.TestCase):
         processed_image = processor(image)
         self.assertIsInstance(processed_image, bytes)
 
+    def test_edpf(self):
+        processor = Processor('edpf')
+        image = Image.open('test_image.png')
+        processed_image = processor(image)
+        self.assertIsInstance(processed_image, bytes)
+
     def test_content_shuffle(self):
         processor = Processor('content_shuffle')
         image = Image.open('test_image.png')

--- a/src/controlnet_aux/tests/test_processor_pytest.py
+++ b/src/controlnet_aux/tests/test_processor_pytest.py
@@ -28,6 +28,7 @@ from controlnet_aux.processor import MODELS, Processor
     'lineart_realistic',
     'lineart_anime',
     'canny',
+    'edpf',
     'shuffle',
     'depth_zoe',
     'depth_leres',

--- a/tests/test_cn_aux_full.json
+++ b/tests/test_cn_aux_full.json
@@ -1,6 +1,6 @@
 {
-  "last_node_id": 45,
-  "last_link_id": 44,
+  "last_node_id": 47,
+  "last_link_id": 46,
   "nodes": [
     {
       "id": 24,
@@ -9,12 +9,12 @@
         843,
         -430
       ],
-      "size": [
-        210,
-        246
-      ],
+      "size": {
+        "0": 210,
+        "1": 246
+      },
       "flags": {},
-      "order": 22,
+      "order": 23,
       "mode": 0,
       "inputs": [
         {
@@ -36,32 +36,7 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
-      },
-      "flags": {},
-      "order": 23,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "images",
-          "type": "IMAGE",
-          "link": 24
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "PreviewImage"
-      }
-    },
-    {
-      "id": 26,
-      "type": "PreviewImage",
-      "pos": [
-        832,
-        -222
-      ],
-      "size": {
-        "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
       "order": 24,
@@ -70,32 +45,7 @@
         {
           "name": "images",
           "type": "IMAGE",
-          "link": 25
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "PreviewImage"
-      }
-    },
-    {
-      "id": 27,
-      "type": "PreviewImage",
-      "pos": [
-        1144,
-        -123
-      ],
-      "size": {
-        "0": 210,
-        "1": 26
-      },
-      "flags": {},
-      "order": 25,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "images",
-          "type": "IMAGE",
-          "link": 26
+          "link": 24
         }
       ],
       "properties": {
@@ -111,10 +61,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 26,
+      "order": 27,
       "mode": 0,
       "inputs": [
         {
@@ -136,10 +86,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 27,
+      "order": 28,
       "mode": 0,
       "inputs": [
         {
@@ -161,10 +111,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 28,
+      "order": 29,
       "mode": 0,
       "inputs": [
         {
@@ -186,10 +136,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 29,
+      "order": 30,
       "mode": 0,
       "inputs": [
         {
@@ -211,10 +161,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 30,
+      "order": 31,
       "mode": 0,
       "inputs": [
         {
@@ -236,10 +186,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 31,
+      "order": 32,
       "mode": 0,
       "inputs": [
         {
@@ -261,10 +211,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 32,
+      "order": 33,
       "mode": 0,
       "inputs": [
         {
@@ -286,10 +236,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 33,
+      "order": 34,
       "mode": 0,
       "inputs": [
         {
@@ -311,10 +261,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 34,
+      "order": 35,
       "mode": 0,
       "inputs": [
         {
@@ -336,10 +286,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 35,
+      "order": 36,
       "mode": 0,
       "inputs": [
         {
@@ -361,10 +311,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 36,
+      "order": 37,
       "mode": 0,
       "inputs": [
         {
@@ -386,10 +336,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 37,
+      "order": 38,
       "mode": 0,
       "inputs": [
         {
@@ -411,10 +361,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 38,
+      "order": 39,
       "mode": 0,
       "inputs": [
         {
@@ -436,10 +386,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 39,
+      "order": 40,
       "mode": 0,
       "inputs": [
         {
@@ -461,10 +411,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 40,
+      "order": 41,
       "mode": 0,
       "inputs": [
         {
@@ -486,10 +436,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 41,
+      "order": 42,
       "mode": 0,
       "inputs": [
         {
@@ -511,7 +461,7 @@
       ],
       "size": {
         "0": 315,
-        "1": 58
+        "1": 82
       },
       "flags": {},
       "order": 1,
@@ -538,7 +488,8 @@
         "Node name for S&R": "PiDiNetPreprocessor"
       },
       "widgets_values": [
-        "enable"
+        "enable",
+        512
       ]
     },
     {
@@ -550,7 +501,7 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 58
       },
       "flags": {},
       "order": 2,
@@ -575,83 +526,10 @@
       ],
       "properties": {
         "Node name for S&R": "ColorPreprocessor"
-      }
-    },
-    {
-      "id": 4,
-      "type": "CannyEdgePreprocessor",
-      "pos": [
-        433,
-        -245
-      ],
-      "size": {
-        "0": 315,
-        "1": 82
-      },
-      "flags": {},
-      "order": 3,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "image",
-          "type": "IMAGE",
-          "link": 3
-        }
-      ],
-      "outputs": [
-        {
-          "name": "IMAGE",
-          "type": "IMAGE",
-          "links": [
-            25
-          ],
-          "shape": 3,
-          "slot_index": 0
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "CannyEdgePreprocessor"
       },
       "widgets_values": [
-        100,
-        200
+        512
       ]
-    },
-    {
-      "id": 5,
-      "type": "SAMPreprocessor",
-      "pos": [
-        427,
-        -108
-      ],
-      "size": {
-        "0": 210,
-        "1": 26
-      },
-      "flags": {},
-      "order": 4,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "image",
-          "type": "IMAGE",
-          "link": 4
-        }
-      ],
-      "outputs": [
-        {
-          "name": "IMAGE",
-          "type": "IMAGE",
-          "links": [
-            26
-          ],
-          "shape": 3,
-          "slot_index": 0
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "SAMPreprocessor"
-      }
     },
     {
       "id": 7,
@@ -662,7 +540,7 @@
       ],
       "size": {
         "0": 315,
-        "1": 106
+        "1": 198
       },
       "flags": {},
       "order": 5,
@@ -683,6 +561,12 @@
           ],
           "shape": 3,
           "slot_index": 0
+        },
+        {
+          "name": "POSE_KEYPOINT",
+          "type": "POSE_KEYPOINT",
+          "links": null,
+          "shape": 3
         }
       ],
       "properties": {
@@ -691,7 +575,10 @@
       "widgets_values": [
         "enable",
         "enable",
-        "enable"
+        "enable",
+        512,
+        "yolox_l.onnx",
+        "dw-ll_ucoco_384_bs5.torchscript.pt"
       ]
     },
     {
@@ -703,7 +590,7 @@
       ],
       "size": {
         "0": 315,
-        "1": 58
+        "1": 82
       },
       "flags": {},
       "order": 6,
@@ -730,7 +617,8 @@
         "Node name for S&R": "BinaryPreprocessor"
       },
       "widgets_values": [
-        100
+        100,
+        512
       ]
     },
     {
@@ -742,7 +630,7 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 58
       },
       "flags": {},
       "order": 7,
@@ -767,7 +655,10 @@
       ],
       "properties": {
         "Node name for S&R": "ScribblePreprocessor"
-      }
+      },
+      "widgets_values": [
+        512
+      ]
     },
     {
       "id": 10,
@@ -778,7 +669,7 @@
       ],
       "size": {
         "0": 315,
-        "1": 82
+        "1": 106
       },
       "flags": {},
       "order": 8,
@@ -806,7 +697,8 @@
       },
       "widgets_values": [
         0.1,
-        0.1
+        0.1,
+        512
       ]
     },
     {
@@ -818,7 +710,7 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 58
       },
       "flags": {},
       "order": 9,
@@ -843,7 +735,10 @@
       ],
       "properties": {
         "Node name for S&R": "UniFormer-SemSegPreprocessor"
-      }
+      },
+      "widgets_values": [
+        512
+      ]
     },
     {
       "id": 12,
@@ -854,7 +749,7 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 58
       },
       "flags": {},
       "order": 10,
@@ -879,7 +774,10 @@
       ],
       "properties": {
         "Node name for S&R": "Zoe-DepthMapPreprocessor"
-      }
+      },
+      "widgets_values": [
+        512
+      ]
     },
     {
       "id": 13,
@@ -890,7 +788,7 @@
       ],
       "size": {
         "0": 315,
-        "1": 82
+        "1": 106
       },
       "flags": {},
       "order": 11,
@@ -918,7 +816,8 @@
       },
       "widgets_values": [
         6.283185307179586,
-        0.1
+        0.1,
+        512
       ]
     },
     {
@@ -930,7 +829,7 @@
       ],
       "size": {
         "0": 315,
-        "1": 82
+        "1": 106
       },
       "flags": {},
       "order": 12,
@@ -958,7 +857,8 @@
       },
       "widgets_values": [
         6.283185307179586,
-        0.1
+        0.1,
+        512
       ]
     },
     {
@@ -970,7 +870,7 @@
       ],
       "size": {
         "0": 315,
-        "1": 106
+        "1": 150
       },
       "flags": {},
       "order": 13,
@@ -991,6 +891,12 @@
           ],
           "shape": 3,
           "slot_index": 0
+        },
+        {
+          "name": "POSE_KEYPOINT",
+          "type": "POSE_KEYPOINT",
+          "links": null,
+          "shape": 3
         }
       ],
       "properties": {
@@ -999,7 +905,8 @@
       "widgets_values": [
         "enable",
         "enable",
-        "enable"
+        "enable",
+        512
       ]
     },
     {
@@ -1010,8 +917,8 @@
         1533
       ],
       "size": {
-        "0": 315,
-        "1": 106
+        "0": 352.79998779296875,
+        "1": 130
       },
       "flags": {},
       "order": 15,
@@ -1040,7 +947,8 @@
       "widgets_values": [
         0,
         0,
-        "enable"
+        "enable",
+        512
       ]
     },
     {
@@ -1052,7 +960,7 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 58
       },
       "flags": {},
       "order": 16,
@@ -1077,7 +985,10 @@
       ],
       "properties": {
         "Node name for S&R": "BAE-NormalMapPreprocessor"
-      }
+      },
+      "widgets_values": [
+        512
+      ]
     },
     {
       "id": 19,
@@ -1088,7 +999,7 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 58
       },
       "flags": {},
       "order": 17,
@@ -1113,7 +1024,10 @@
       ],
       "properties": {
         "Node name for S&R": "OneFormer-COCO-SemSegPreprocessor"
-      }
+      },
+      "widgets_values": [
+        512
+      ]
     },
     {
       "id": 20,
@@ -1123,8 +1037,8 @@
         1941
       ],
       "size": {
-        "0": 210,
-        "1": 26
+        "0": 218.39999389648438,
+        "1": 58
       },
       "flags": {},
       "order": 18,
@@ -1149,7 +1063,10 @@
       ],
       "properties": {
         "Node name for S&R": "OneFormer-ADE20K-SemSegPreprocessor"
-      }
+      },
+      "widgets_values": [
+        512
+      ]
     },
     {
       "id": 22,
@@ -1159,8 +1076,8 @@
         2193
       ],
       "size": {
-        "0": 315,
-        "1": 58
+        "0": 319.20001220703125,
+        "1": 82
       },
       "flags": {},
       "order": 20,
@@ -1187,7 +1104,8 @@
         "Node name for S&R": "FakeScribblePreprocessor"
       },
       "widgets_values": [
-        "enable"
+        "enable",
+        512
       ]
     },
     {
@@ -1199,7 +1117,7 @@
       ],
       "size": {
         "0": 315,
-        "1": 58
+        "1": 82
       },
       "flags": {},
       "order": 19,
@@ -1226,7 +1144,8 @@
         "Node name for S&R": "HEDPreprocessor"
       },
       "widgets_values": [
-        "enable"
+        "enable",
+        512
       ]
     },
     {
@@ -1238,7 +1157,7 @@
       ],
       "size": {
         "0": 315,
-        "1": 58
+        "1": 82
       },
       "flags": {},
       "order": 14,
@@ -1265,7 +1184,8 @@
         "Node name for S&R": "LineArtPreprocessor"
       },
       "widgets_values": [
-        "enable"
+        "enable",
+        512
       ]
     },
     {
@@ -1277,10 +1197,10 @@
       ],
       "size": {
         "0": 210,
-        "1": 26
+        "1": 246
       },
       "flags": {},
-      "order": 42,
+      "order": 43,
       "mode": 0,
       "inputs": [
         {
@@ -1302,7 +1222,7 @@
       ],
       "size": {
         "0": 315,
-        "1": 58
+        "1": 82
       },
       "flags": {},
       "order": 21,
@@ -1329,7 +1249,88 @@
         "Node name for S&R": "TilePreprocessor"
       },
       "widgets_values": [
-        3
+        3,
+        512
+      ]
+    },
+    {
+      "id": 4,
+      "type": "CannyEdgePreprocessor",
+      "pos": [
+        433,
+        -245
+      ],
+      "size": {
+        "0": 315,
+        "1": 106
+      },
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 3
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            25
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CannyEdgePreprocessor"
+      },
+      "widgets_values": [
+        100,
+        200,
+        512
+      ]
+    },
+    {
+      "id": 5,
+      "type": "SAMPreprocessor",
+      "pos": [
+        437,
+        5
+      ],
+      "size": {
+        "0": 210,
+        "1": 58
+      },
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 4
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            26
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SAMPreprocessor"
+      },
+      "widgets_values": [
+        512
       ]
     },
     {
@@ -1371,7 +1372,8 @@
             19,
             20,
             21,
-            44
+            44,
+            45
           ],
           "shape": 3,
           "slot_index": 0
@@ -1389,6 +1391,120 @@
       "widgets_values": [
         "pose.png",
         "image"
+      ]
+    },
+    {
+      "id": 26,
+      "type": "PreviewImage",
+      "pos": [
+        832,
+        -222
+      ],
+      "size": {
+        "0": 210,
+        "1": 246
+      },
+      "flags": {},
+      "order": 25,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 25
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PreviewImage"
+      }
+    },
+    {
+      "id": 47,
+      "type": "PreviewImage",
+      "pos": [
+        1055,
+        -219
+      ],
+      "size": {
+        "0": 210,
+        "1": 26
+      },
+      "flags": {},
+      "order": 44,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 46
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PreviewImage"
+      }
+    },
+    {
+      "id": 27,
+      "type": "PreviewImage",
+      "pos": [
+        1407,
+        -240
+      ],
+      "size": {
+        "0": 210,
+        "1": 246
+      },
+      "flags": {},
+      "order": 26,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 26
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PreviewImage"
+      }
+    },
+    {
+      "id": 46,
+      "type": "EDPFPreprocessor",
+      "pos": [
+        433,
+        -100
+      ],
+      "size": {
+        "0": 315,
+        "1": 58
+      },
+      "flags": {},
+      "order": 22,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 45
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            46
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "EDPFPreprocessor"
+      },
+      "widgets_values": [
+        512
       ]
     }
   ],
@@ -1728,10 +1844,34 @@
       44,
       0,
       "IMAGE"
+    ],
+    [
+      45,
+      1,
+      0,
+      46,
+      0,
+      "IMAGE"
+    ],
+    [
+      46,
+      46,
+      0,
+      47,
+      0,
+      "IMAGE"
     ]
   ],
   "groups": [],
   "config": {},
-  "extra": {},
+  "extra": {
+    "ds": {
+      "scale": 0.620921323059155,
+      "offset": [
+        553.9708801007812,
+        372.455134808526
+      ]
+    }
+  },
   "version": 0.4
 }

--- a/tests/test_controlnet_aux.py
+++ b/tests/test_controlnet_aux.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 from PIL import Image
 
-from controlnet_aux import (CannyDetector, ContentShuffleDetector, HEDdetector,
+from controlnet_aux import (CannyDetector, EDPF, ContentShuffleDetector, HEDdetector,
                             LeresDetector, LineartAnimeDetector,
                             LineartDetector, MediapipeFaceDetector,
                             MidasDetector, MLSDdetector, NormalBaeDetector,
@@ -44,6 +44,11 @@ def test_canny(img):
     canny = CannyDetector()
     common("canny", canny, img)
     output("canny_img", canny(img=img))
+
+def test_edpf(img):
+    edpf = EDPF()
+    common("edpf", edpf, img)
+    output("edpf_img", edpf(img=img))
 
 def test_hed(img):
     hed = HEDdetector.from_pretrained("lllyasviel/Annotators")


### PR DESCRIPTION
adds an edge-drawing parameter-free (EDPF) preprocessor for the following controlnet: https://civitai.com/models/149740
This is similar to ControlNet Canny but uses [a modern algorithm](https://github.com/CihanTopal/ED_Lib) for edge-detection which requires no parameter tuning (Canny was invented in 1986, Edge Drawing in 2012).

please note: this requires opencv-contrib as outlined here https://github.com/Fannovel16/comfyui_controlnet_aux/discussions/355
it seems to work when i add opencv-contrib in requirements last (after mediapipe and albumentations add opencv). however it make break if any other custom node installs opencv afterwards. i don't know what the best way to handle this is yet.