### PR TITLE
Don't override environment variables

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -16,7 +16,7 @@ for pkg_name in ["controlnet_aux", "custom_mmpkg"]:
 #Enable CPU fallback for ops not being supported by MPS like upsample_bicubic2d.out
 #https://github.com/pytorch/pytorch/issues/77764
 #https://github.com/Fannovel16/comfyui_controlnet_aux/issues/2#issuecomment-1763579485
-os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = '1' 
+os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = os.getenv("PYTORCH_ENABLE_MPS_FALLBACK", '1')
 
 
 def load_nodes():

--- a/utils.py
+++ b/utils.py
@@ -48,10 +48,10 @@ else:
     USE_SYMLINKS = False
     ORT_PROVIDERS = ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "CPUExecutionProvider", "CoreMLExecutionProvider"]
 
-os.environ['AUX_ANNOTATOR_CKPTS_PATH'] = annotator_ckpts_path
-os.environ['AUX_TEMP_DIR'] = str(TEMP_DIR)
-os.environ['AUX_USE_SYMLINKS'] = str(USE_SYMLINKS)
-os.environ['AUX_ORT_PROVIDERS'] = str(",".join(ORT_PROVIDERS))
+os.environ['AUX_ANNOTATOR_CKPTS_PATH'] = os.getenv('AUX_ANNOTATOR_CKPTS_PATH', annotator_ckpts_path)
+os.environ['AUX_TEMP_DIR'] = os.getenv('AUX_TEMP_DIR', str(TEMP_DIR))
+os.environ['AUX_USE_SYMLINKS'] = os.getenv('AUX_USE_SYMLINKS', str(USE_SYMLINKS))
+os.environ['AUX_ORT_PROVIDERS'] = os.getenv('AUX_ORT_PROVIDERS', str(",".join(ORT_PROVIDERS)))
 
 log.info(f"Using ckpts path: {annotator_ckpts_path}")
 log.info(f"Using symlinks: {USE_SYMLINKS}")


### PR DESCRIPTION
Typically with production apps there's a hierarchy that looks like this:

env vars > config values > defaults

It's very useful to override the defaults with config files or environment variables. This PR makes it so this module respects `AUX_*` environment variables and doesn't override them if they are defined.