### PR TITLE
fix: fix tight_bbox related error in MeshGraphormer

### DIFF
--- a/node_wrappers/mesh_graphormer.py
+++ b/node_wrappers/mesh_graphormer.py
@@ -79,7 +79,7 @@ class Mesh_Graphormer_Depth_Map_Preprocessor:
 
             elif mask_type == "tight_bboxes":
                 mask = np.zeros_like(mask)
-                hand_bboxes = info["abs_boxes"]
+                hand_bboxes = (info or {}).get("abs_boxes") or []
                 for hand_bbox in hand_bboxes: 
                     x_min, x_max, y_min, y_max = hand_bbox
                     mask[y_min:y_max+1, x_min:x_max+1, :] = 255 #HWC


### PR DESCRIPTION
when mask_type tight_bbox is selected and there are no hands in the original picture, MeshGraphormer crashed with a `NoneType is not subscriptable` error. This change should fix this error and make sure the node runs through with an empty mask instead.