### PR TITLE
Pinning equivalent dependencies for controlnet aux dinov2

### DIFF
--- a/src/controlnet_aux/depth_anything/torchhub/facebookresearch_dinov2_main/requirements.txt
+++ b/src/controlnet_aux/depth_anything/torchhub/facebookresearch_dinov2_main/requirements.txt
@@ -1,11 +1,11 @@
 --extra-index-url https://download.pytorch.org/whl/cu117
-torch==2.0.0
-torchvision==0.15.0
+torch~=2.0.0
+torchvision~=0.15.0
 omegaconf
-torchmetrics==0.10.3
+torchmetrics~=0.10.3
 fvcore
 iopath
-xformers==0.0.18
+xformers~=0.0.18
 submitit
 --extra-index-url https://pypi.nvidia.com
 cuml-cu11


### PR DESCRIPTION
Hello

Trying to install the node along others, we had some dependency conflicts on torch (another plugin was requiring 2.0.1).

Is it ok to use equivalent dependencies on your side ? It should work since it would accept any bugfix done after torch 2.0.0

thanks