### PR TITLE
added bash installer and removed license from pyproject.toml

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+requirements_txt="$(dirname "$0")/requirements.txt"
+python_exec="../../../python_embeded/python.exe"
+
+echo "Installing ComfyUI's ControlNet Auxiliary Preprocessors.."
+
+if [ -f "$python_exec" ]; then
+    echo "Installing with ComfyUI Portable"
+    while IFS= read -r line; do
+        "$python_exec" -s -m pip install "$line"
+    done < "$requirements_txt"
+else
+    echo "Installing with system Python"
+    while IFS= read -r line; do
+        pip install "$line"
+    done < "$requirements_txt"
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,15 @@
 [project]
 name = "comfyui_controlnet_aux"
 description = "Plug-and-play ComfyUI node sets for making ControlNet hint images"
+<<<<<<< Updated upstream
 
 version = "1.0.4-alpha.7"
 license = { file = "LICENSE.txt" }
 dependencies = ["torch", "importlib_metadata", "huggingface_hub", "scipy", "opencv-python>=4.7.0.72", "filelock", "numpy", "Pillow", "einops", "torchvision", "pyyaml", "scikit-image", "python-dateutil", "mediapipe", "svglib", "fvcore", "yapf", "omegaconf", "ftfy", "addict", "yacs", "trimesh[easy]", "albumentations", "scikit-learn", "matplotlib"]
+=======
+version = "1.0.4-alpha.4"
+dependencies = ["torch", "importlib_metadata", "huggingface_hub", "scipy", "opencv-python>=4.7.0.72", "filelock", "numpy", "Pillow", "einops", "torchvision", "pyyaml", "scikit-image", "python-dateutil", "mediapipe", "svglib", "fvcore", "yapf", "omegaconf", "ftfy", "addict", "yacs", "trimesh[easy]", "albumentations", "scikit-learn"]
+>>>>>>> Stashed changes
 
 [project.urls]
 Repository = "https://github.com/Fannovel16/comfyui_controlnet_aux"


### PR DESCRIPTION
Had an issue with installing, pyproject.toml was complaining about two references to the licensee, I removed the one in the pyproject.toml file since the LICENSE.txt was already there. 
Also added an install.sh that has the same functionality as the install.bat for linux users. 