### PR TITLE
Add black_pixel_for_xinsr_cn on InpaintPreprocessor

### DIFF
--- a/node_wrappers/inpaint.py
+++ b/node_wrappers/inpaint.py
@@ -6,18 +6,18 @@ class InpaintPreprocessor:
     def INPUT_TYPES(s):
         return dict(
             required=dict(image=INPUT.IMAGE(), mask=INPUT.MASK()),
-            optional=dict(black_pixel_for_xinsr_cn=INPUT.BOOLEAN(False))
+            optional=dict(black_pixel_for_xinsir_cn=INPUT.BOOLEAN(False))
         )
     RETURN_TYPES = ("IMAGE",)
     FUNCTION = "preprocess"
 
     CATEGORY = "ControlNet Preprocessors/others"
 
-    def preprocess(self, image, mask, black_pixel_for_xinsr_cn=False):
+    def preprocess(self, image, mask, black_pixel_for_xinsir_cn=False):
         mask = torch.nn.functional.interpolate(mask.reshape((-1, 1, mask.shape[-2], mask.shape[-1])), size=(image.shape[1], image.shape[2]), mode="bilinear")
         mask = mask.movedim(1,-1).expand((-1,-1,-1,3))
         image = image.clone()
-        if black_pixel_for_xinsr_cn:
+        if black_pixel_for_xinsir_cn:
             masked_pixel = 0.0
         else:
             masked_pixel = -1.0

--- a/node_wrappers/inpaint.py
+++ b/node_wrappers/inpaint.py
@@ -5,18 +5,23 @@ class InpaintPreprocessor:
     @classmethod
     def INPUT_TYPES(s):
         return dict(
-            required=dict(image=INPUT.IMAGE(), mask=INPUT.MASK())
+            required=dict(image=INPUT.IMAGE(), mask=INPUT.MASK()),
+            optional=dict(black_pixel_for_xinsr_cn=INPUT.BOOLEAN(False))
         )
     RETURN_TYPES = ("IMAGE",)
     FUNCTION = "preprocess"
 
     CATEGORY = "ControlNet Preprocessors/others"
 
-    def preprocess(self, image, mask):
+    def preprocess(self, image, mask, black_pixel_for_xinsr_cn=False):
         mask = torch.nn.functional.interpolate(mask.reshape((-1, 1, mask.shape[-2], mask.shape[-1])), size=(image.shape[1], image.shape[2]), mode="bilinear")
         mask = mask.movedim(1,-1).expand((-1,-1,-1,3))
         image = image.clone()
-        image[mask > 0.5] = -1.0  # set as masked pixel
+        if black_pixel_for_xinsr_cn:
+            masked_pixel = 0.0
+        else:
+            masked_pixel = -1.0
+        image[mask > 0.5] = masked_pixel
         return (image,)
 
 NODE_CLASS_MAPPINGS = {


### PR DESCRIPTION
Xinsir6's controlnet-union-sdxl-promax requires black pixels (0,0,0) for masked areas in input images when using the repaint control type, which differs from the standard ControlNet requirement (-1,-1,-1).

To address this, I've added a `black_pixel_for_xinsr_cn` option to the Inpaint Preprocessor, allowing support for this special case. To maintain compatibility, this option is disabled by default.

This change should resolve issue #408.
 
Reference: https://github.com/Kosinkadink/ComfyUI-Advanced-ControlNet/issues/133#issuecomment-2239955689



