### PR TITLE
Update __init__.py Resolve the issue of misaligned images after tile …

### DIFF
--- a/src/custom_controlnet_aux/tile/__init__.py
+++ b/src/custom_controlnet_aux/tile/__init__.py
@@ -18,6 +18,12 @@ class TileDetector:
         for _ in range(pyrUp_iters):
             detected_map = cv2.pyrUp(detected_map)
 
+        shift = 2 ** (pyrUp_iters - 1) if pyrUp_iters > 0 else 0
+        M = np.float32([[1, 0, shift], [0, 1, shift]])
+        corrected_map = cv2.warpAffine(detected_map, M, (W, H), borderMode=cv2.BORDER_REFLECT_101)
+        if H != orig_H or W != orig_W:
+            corrected_map = corrected_map[0:orig_H, 0:orig_W]
+
         if output_type == "pil":
             detected_map = Image.fromarray(detected_map)
 


### PR DESCRIPTION
…processing.

Resolved an issue where the tile preprocessor shifted 4 pixels to the upper left relative to the original image when calling cv2.pyrUp three times.

Original image
![5035-0](https://github.com/user-attachments/assets/f36d1dd2-a312-4796-8ece-0d97c72c960a)

Before modification
<img width="1024" height="1024" alt="ComfyUI_temp_yyusa_00001_ (1)" src="https://github.com/user-attachments/assets/bf790130-8b7a-47ed-b4b3-934afa802d30" />

After modification
<img width="1024" height="1024" alt="ComfyUI_temp_efeuj_00002_" src="https://github.com/user-attachments/assets/469dea3f-9092-4d84-acb9-0aafe17d8582" />
