### PR TITLE
removed unused svg lib to fix broken comfydeploy build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "comfyui_controlnet_aux"
 description = "Plug-and-play ComfyUI node sets for making ControlNet hint images"
 
 version = "1.1.2"
-dependencies = ["torch", "importlib_metadata", "huggingface_hub", "scipy", "opencv-python>=4.7.0.72", "filelock", "numpy", "Pillow", "einops", "torchvision", "pyyaml", "scikit-image", "python-dateutil", "mediapipe", "svglib", "fvcore", "yapf", "omegaconf", "ftfy", "addict", "yacs", "trimesh[easy]", "albumentations", "scikit-learn", "matplotlib"]
+dependencies = ["torch", "importlib_metadata", "huggingface_hub", "scipy", "opencv-python>=4.7.0.72", "filelock", "numpy", "Pillow", "einops", "torchvision", "pyyaml", "scikit-image", "python-dateutil", "mediapipe", "fvcore", "yapf", "omegaconf", "ftfy", "addict", "yacs", "trimesh[easy]", "albumentations", "scikit-learn", "matplotlib"]
 
 [project.urls]
 Repository = "https://github.com/Fannovel16/comfyui_controlnet_aux"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ pyyaml
 scikit-image
 python-dateutil
 mediapipe
-svglib
 fvcore
 yapf
 omegaconf


### PR DESCRIPTION
Removing svglib to streamline provisioning, and prevent a conflict it was creating on comfydeploy with pycairo/pkg-config/gcc.

If it is in use somewhere that I can't see, please close and let me know.