### PR TITLE
Added unloading of the model from memory for DWPose Estimator

### DIFF
--- a/src/custom_controlnet_aux/dwpose/__init__.py
+++ b/src/custom_controlnet_aux/dwpose/__init__.py
@@ -255,6 +255,10 @@ class DwposeDetector:
             keypoints_info = self.dw_pose_estimation(oriImg.copy())
             return Wholebody.format_result(keypoints_info)
     
+    def unload(self):
+        global global_cached_dwpose
+        global_cached_dwpose = Wholebody()
+
     def __call__(self, input_image, detect_resolution=512, include_body=True, include_hand=False, include_face=False, hand_and_face=None, output_type="pil", image_and_json=False, upscale_method="INTER_CUBIC", xinsr_stick_scaling=False, **kwargs):
         if hand_and_face is not None:
             warnings.warn("hand_and_face is deprecated. Use include_hand and include_face instead.", DeprecationWarning)


### PR DESCRIPTION
The idea of unloading the model came to me when working with Wan Animate on a video card with 6GB of VRAM. I had to reduce the size of the video and image to fit all the models into the video memory.

This is inconvenient, and I wanted to be able to unload unused models from memory. That's how this PR turned out. Here I have set a new parameter `keep_model_loaded` in **DWPose_Preprocessor (DWPose Estimator)**. This parameter allows you to leave the model in memory or unload it after the node is executed.