### PR TITLE
Improved caching behavior. Removed excessive network requests. 

### DIFF
--- a/src/custom_controlnet_aux/depth_anything/transformers.py
+++ b/src/custom_controlnet_aux/depth_anything/transformers.py
@@ -15,7 +15,13 @@ class DepthAnythingDetector:
     
     def __init__(self, model_name="LiheYoung/depth-anything-large-hf"):
         """Initialize DepthAnything with specified model."""
-        self.pipe = pipeline(task="depth-estimation", model=model_name)
+        from transformers import AutoImageProcessor, AutoModelForDepthEstimation
+        try:
+            image_processor = AutoImageProcessor.from_pretrained(model_name, local_files_only=True)
+            model = AutoModelForDepthEstimation.from_pretrained(model_name, local_files_only=True)
+            self.pipe = pipeline(task="depth-estimation", model=model, image_processor=image_processor)
+        except Exception as e:
+            self.pipe = pipeline(task="depth-estimation", model=model_name)
         self.device = "cpu"
 
     @classmethod  

--- a/src/custom_controlnet_aux/midas/transformers.py
+++ b/src/custom_controlnet_aux/midas/transformers.py
@@ -17,8 +17,12 @@ class MidasDetector:
         from transformers import DPTForDepthEstimation, DPTImageProcessor
         
         self.model_name = model_name
-        self.processor = DPTImageProcessor.from_pretrained(model_name)
-        self.model = DPTForDepthEstimation.from_pretrained(model_name)
+        try:
+            self.processor = DPTImageProcessor.from_pretrained(model_name, local_files_only=True)
+            self.model = DPTForDepthEstimation.from_pretrained(model_name, local_files_only=True)
+        except Exception as e:
+            self.processor = DPTImageProcessor.from_pretrained(model_name)
+            self.model = DPTForDepthEstimation.from_pretrained(model_name)
         self.device = "cpu"
 
     @classmethod  

--- a/src/custom_controlnet_aux/oneformer/transformers.py
+++ b/src/custom_controlnet_aux/oneformer/transformers.py
@@ -26,8 +26,12 @@ class OneformerSegmentor:
         from transformers import OneFormerProcessor, OneFormerForUniversalSegmentation
         
         self.model_name = model_name
-        self.processor = OneFormerProcessor.from_pretrained(model_name)
-        self.model = OneFormerForUniversalSegmentation.from_pretrained(model_name)
+        try:
+            self.processor = OneFormerProcessor.from_pretrained(model_name, local_files_only=True)
+            self.model = OneFormerForUniversalSegmentation.from_pretrained(model_name, local_files_only=True)
+        except Exception as e:
+            self.processor = OneFormerProcessor.from_pretrained(model_name)
+            self.model = OneFormerForUniversalSegmentation.from_pretrained(model_name)
         self.device = "cpu"
 
     @classmethod  

--- a/src/custom_controlnet_aux/sam/sam.py
+++ b/src/custom_controlnet_aux/sam/sam.py
@@ -16,8 +16,12 @@ class SamDetector:
         from transformers import SamModel, SamProcessor
         
         self.model_name = model_name
-        self.processor = SamProcessor.from_pretrained(model_name)
-        self.model = SamModel.from_pretrained(model_name)
+        try:
+            self.processor = SamProcessor.from_pretrained(model_name, local_files_only=True)
+            self.model = SamModel.from_pretrained(model_name, local_files_only=True)
+        except Exception as e:
+            self.processor = SamProcessor.from_pretrained(model_name)
+            self.model = SamModel.from_pretrained(model_name)
         self.device = "cpu"
 
     @classmethod  

--- a/src/custom_controlnet_aux/zoe/transformers.py
+++ b/src/custom_controlnet_aux/zoe/transformers.py
@@ -92,7 +92,12 @@ class ZoeDetector:
     
     def __init__(self, model_name="Intel/zoedepth-nyu-kitti"):
         """Initialize ZoeDepth with specified model."""
-        self.pipe = pipeline(task="depth-estimation", model=model_name)
+        try:
+            image_processor = AutoImageProcessor.from_pretrained(model_name, local_files_only=True)
+            model = ZoeDepthForDepthEstimation.from_pretrained(model_name, local_files_only=True)
+            self.pipe = pipeline(task="depth-estimation", model=model, image_processor=image_processor)
+        except Exception as e:
+            self.pipe = pipeline(task="depth-estimation", model=model_name)
         self.device = "cpu"
 
     @classmethod  
@@ -147,7 +152,12 @@ class ZoeDepthAnythingDetector:
     
     def __init__(self, model_name="Intel/zoedepth-nyu-kitti"):
         """Initialize ZoeDepthAnything detector."""
-        self.pipe = pipeline(task="depth-estimation", model=model_name)
+        try:
+            image_processor = AutoImageProcessor.from_pretrained(model_name, local_files_only=True)
+            model = ZoeDepthForDepthEstimation.from_pretrained(model_name, local_files_only=True)
+            self.pipe = pipeline(task="depth-estimation", model=model, image_processor=image_processor)
+        except Exception as e:
+            self.pipe = pipeline(task="depth-estimation", model=model_name)
         self.device = "cpu"
 
     @classmethod  


### PR DESCRIPTION
By default, even if a cached model is available, HF methods will make network requests anyway.

Made changes to use cached models first without making any network requests. If it fails to fetch a cached model, it will download the missing one.

The original behavior causes multiple retries and delays if the internet is unstable. It is especially frustrating if you know you already have models cached.