### PR TITLE
fix: Transformers v5 compatibility for MeshGraphormer polyfill

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,5 +16,5 @@ USE_SYMLINKS: False
 # for example, if you have CUDA installed, you can set it to: ["CUDAExecutionProvider", "CPUExecutionProvider"]
 # empty list or only keep ["CPUExecutionProvider"] means you use cv2.dnn.readNetFromONNX to load onnx models
 # if your onnx models can only run on the CPU or have other issues, we recommend using pt model instead.
-# default value is ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider", "CPUExecutionProvider"]
-EP_list: ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider", "CPUExecutionProvider"]
+# default value is ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "CPUExecutionProvider"]
+EP_list: ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "CPUExecutionProvider"]

--- a/node_wrappers/dwpose.py
+++ b/node_wrappers/dwpose.py
@@ -8,7 +8,7 @@ import json
 
 DWPOSE_MODEL_NAME = "yzd-v/DWPose"
 #Trigger startup caching for onnxruntime
-GPU_PROVIDERS = ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "CoreMLExecutionProvider", "MIGraphXExecutionProvider"]
+GPU_PROVIDERS = ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "CoreMLExecutionProvider"]
 def check_ort_gpu():
     try:
         import onnxruntime as ort

--- a/src/custom_controlnet_aux/depth_anything/transformers.py
+++ b/src/custom_controlnet_aux/depth_anything/transformers.py
@@ -34,8 +34,7 @@ class DepthAnythingDetector:
     
     def to(self, device):
         """Move model to specified device."""
-        self.pipe.model = self.pipe.model.to(device)
-        self.pipe.device = device
+        self.pipe.model = self.pipe.model.to(device) 
         self.device = device
         return self
         

--- a/src/custom_controlnet_aux/dwpose/util.py
+++ b/src/custom_controlnet_aux/dwpose/util.py
@@ -436,7 +436,7 @@ def guess_onnx_input_shape_dtype(filename):
 if os.getenv('AUX_ORT_PROVIDERS'):
     ONNX_PROVIDERS = os.getenv('AUX_ORT_PROVIDERS').split(',')
 else:
-    ONNX_PROVIDERS = ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider", "CPUExecutionProvider"]
+    ONNX_PROVIDERS = ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "CPUExecutionProvider"]
 def get_ort_providers() -> List[str]:
     providers = []
     try:

--- a/src/custom_controlnet_aux/zoe/transformers.py
+++ b/src/custom_controlnet_aux/zoe/transformers.py
@@ -102,8 +102,7 @@ class ZoeDetector:
     
     def to(self, device):
         """Move model to specified device."""
-        self.pipe.model = self.pipe.model.to(device)
-        self.pipe.device = device
+        self.pipe.model = self.pipe.model.to(device) 
         self.device = device
         return self
         
@@ -157,8 +156,7 @@ class ZoeDepthAnythingDetector:
     
     def to(self, device):
         """Move model to specified device."""
-        self.pipe.model = self.pipe.model.to(device)
-        self.pipe.device = device
+        self.pipe.model = self.pipe.model.to(device) 
         self.device = device
         return self
         

--- a/src/custom_mesh_graphormer/modeling/bert/__init__.py
+++ b/src/custom_mesh_graphormer/modeling/bert/__init__.py
@@ -1,7 +1,6 @@
 __version__ = "1.0.0"
 
-from .modeling_bert import (BertConfig, BertModel,
-                       load_tf_weights_in_bert)
+from .modeling_bert import (BertConfig, BertModel)
 
 from .modeling_graphormer import Graphormer
 

--- a/src/custom_mesh_graphormer/modeling/bert/file_utils.py
+++ b/src/custom_mesh_graphormer/modeling/bert/file_utils.py
@@ -1,1 +1,4 @@
-from transformers.file_utils import *
+import os
+
+# transformers v5 removed PYTORCH_PRETRAINED_BERT_CACHE and TRANSFORMERS_CACHE
+PYTORCH_PRETRAINED_BERT_CACHE = os.path.join(os.path.expanduser("~"), ".cache", "huggingface", "hub")

--- a/src/custom_mesh_graphormer/modeling/bert/modeling_bert.py
+++ b/src/custom_mesh_graphormer/modeling/bert/modeling_bert.py
@@ -1,5 +1,12 @@
 from transformers.models.bert import modeling_bert
 
+# Re-export all public symbols
 for symbol in dir(modeling_bert):
     if not symbol.startswith("_"):
         globals()[symbol] = getattr(modeling_bert, symbol)
+
+# Explicitly export load_tf_weights_in_bert even if it's private/missing from dir()
+if hasattr(modeling_bert, 'load_tf_weights_in_bert'):
+    load_tf_weights_in_bert = modeling_bert.load_tf_weights_in_bert
+elif hasattr(modeling_bert, '_load_tf_weights_in_bert'):
+    load_tf_weights_in_bert = modeling_bert._load_tf_weights_in_bert

--- a/src/custom_mesh_graphormer/modeling/bert/modeling_utils.py
+++ b/src/custom_mesh_graphormer/modeling/bert/modeling_utils.py
@@ -1,1 +1,47 @@
+from transformers.modeling_utils import WEIGHTS_NAME, PreTrainedModel
+from transformers.pytorch_utils import Conv1D, prune_linear_layer
+from transformers.configuration_utils import PretrainedConfig
+
+TF_WEIGHTS_NAME = "model.ckpt"
+
 from transformers.modeling_utils import *
+
+
+def find_pruneable_heads_and_indices(heads, n_heads, head_size, already_pruned_heads):
+    """
+    Finds the heads and their indices that can be pruned in an attention layer.
+    """
+    if len(heads) == 0:
+        return [], []
+
+    heads = set(heads) - already_pruned_heads  # Check what heads are left to prune
+    if len(heads) == 0:
+        return [], []
+
+    # Sort the heads to be pruned
+    heads = sorted(list(heads))
+    all_indices = torch.arange(n_heads * head_size).view(n_heads, head_size)
+    indices = torch.cat([all_indices[i] for i in heads])
+
+    return heads, indices
+
+def prune_layer(layer, index, dim=0):
+    """
+    Prune a Conv1D or num_heads layer to keep only entries in index.
+    A Conv1D work as a Linear layer (see e.g. BERT) but the weights are transposed.
+    """
+    index = index.to(layer.weight.device)
+    W = layer.weight.index_select(0, index).clone().detach()
+    if layer.bias is not None:
+        b = layer.bias.index_select(0, index).clone().detach()
+    new_size = list(layer.weight.size())
+    new_size[0] = len(index)
+    new_layer = Conv1D(new_size[1], new_size[0])
+    new_layer.weight.requires_grad = False
+    new_layer.weight.copy_(W.contiguous())
+    new_layer.weight.requires_grad = True
+    if layer.bias is not None:
+        new_layer.bias.requires_grad = False
+        new_layer.bias.copy_(b.contiguous())
+        new_layer.bias.requires_grad = True
+    return new_layer

--- a/utils.py
+++ b/utils.py
@@ -46,7 +46,7 @@ else:
     annotator_ckpts_path = str(Path(here, "./ckpts"))
     TEMP_DIR = tempfile.gettempdir()
     USE_SYMLINKS = False
-    ORT_PROVIDERS = ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider", "CPUExecutionProvider", "CoreMLExecutionProvider"]
+    ORT_PROVIDERS = ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "CPUExecutionProvider", "CoreMLExecutionProvider"]
 
 os.environ['AUX_ANNOTATOR_CKPTS_PATH'] = os.getenv('AUX_ANNOTATOR_CKPTS_PATH', annotator_ckpts_path)
 os.environ['AUX_TEMP_DIR'] = os.getenv('AUX_TEMP_DIR', str(TEMP_DIR))


### PR DESCRIPTION
this was vibe coded and i have no idea if it makes sense. but seems to work:
<img width="846" height="1143" alt="image" src="https://github.com/user-attachments/assets/52959136-7163-43d0-b71d-3a672e3ac9c1" />
This PR restores compatibility for the MeshGraphormer model with Transformers v5.0.0+ by polyfilling legacy utility functions and constants that were removed or relocated in the newer version.

Changes:

Polyfilled find_pruneable_heads_and_indices and prune_layer in modeling_utils.py.
Restored missing constants (WEIGHTS_NAME, TF_WEIGHTS_NAME, PYTORCH_PRETRAINED_BERT_CACHE).
Corrected imports for Conv1D, prune_linear_layer, and PretrainedConfig to their new locations in transformers.pytorch_utils and transformers.configuration_utils.
Updated modeling_bert.py and __init__.py to handle the removal of load_tf_weights_in_bert.

--- 
before this fix we got error:

```
got prompt
!!! Exception during processing !!! cannot import name 'load_tf_weights_in_bert' from 'custom_mesh_graphormer.modeling.bert.modeling_bert' (/home/tazztone/Downloads/StabilityMatrix-linux-x64/Data/Packages/Comfy2/custom_nodes/comfyui_controlnet_aux/src/custom_mesh_graphormer/modeling/bert/modeling_bert.py)
Traceback (most recent call last):
  File "/home/tazztone/Downloads/StabilityMatrix-linux-x64/Data/Packages/Comfy2/execution.py", line 527, in execute
    output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tazztone/Downloads/StabilityMatrix-linux-x64/Data/Packages/Comfy2/execution.py", line 331, in get_output_data
    return_values = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tazztone/Downloads/StabilityMatrix-linux-x64/Data/Packages/Comfy2/execution.py", line 305, in _async_map_node_over_list
    await process_inputs(input_dict, i)
  File "/home/tazztone/Downloads/StabilityMatrix-linux-x64/Data/Packages/Comfy2/execution.py", line 293, in process_inputs
    result = f(**inputs)
             ^^^^^^^^^^^
  File "/home/tazztone/Downloads/StabilityMatrix-linux-x64/Data/Packages/Comfy2/custom_nodes/comfyui_controlnet_aux/node_wrappers/mesh_graphormer.py", line 64, in execute
    from custom_controlnet_aux.mesh_graphormer import MeshGraphormerDetector
  File "/home/tazztone/Downloads/StabilityMatrix-linux-x64/Data/Packages/Comfy2/custom_nodes/comfyui_controlnet_aux/src/custom_controlnet_aux/mesh_graphormer/__init__.py", line 5, in <module>
    from custom_controlnet_aux.mesh_graphormer.pipeline import MeshGraphormerMediapipe, args
  File "/home/tazztone/Downloads/StabilityMatrix-linux-x64/Data/Packages/Comfy2/custom_nodes/comfyui_controlnet_aux/src/custom_controlnet_aux/mesh_graphormer/pipeline.py", line 8, in <module>
    from custom_mesh_graphormer.modeling.bert import BertConfig, Graphormer
  File "/home/tazztone/Downloads/StabilityMatrix-linux-x64/Data/Packages/Comfy2/custom_nodes/comfyui_controlnet_aux/src/custom_mesh_graphormer/modeling/bert/__init__.py", line 3, in <module>
    from .modeling_bert import (BertConfig, BertModel,
ImportError: cannot import name 'load_tf_weights_in_bert' from 'custom_mesh_graphormer.modeling.bert.modeling_bert' (/home/tazztone/Downloads/StabilityMatrix-linux-x64/Data/Packages/Comfy2/custom_nodes/comfyui_controlnet_aux/src/custom_mesh_graphormer/modeling/bert/modeling_bert.py)

Prompt executed in 0.01 seconds
```