### PR TITLE
Add the MIGraphXExecutionProvider

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,5 +16,5 @@ USE_SYMLINKS: False
 # for example, if you have CUDA installed, you can set it to: ["CUDAExecutionProvider", "CPUExecutionProvider"]
 # empty list or only keep ["CPUExecutionProvider"] means you use cv2.dnn.readNetFromONNX to load onnx models
 # if your onnx models can only run on the CPU or have other issues, we recommend using pt model instead.
-# default value is ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "CPUExecutionProvider"]
-EP_list: ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "CPUExecutionProvider"]
+# default value is ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider", "CPUExecutionProvider"]
+EP_list: ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider", "CPUExecutionProvider"]

--- a/node_wrappers/dwpose.py
+++ b/node_wrappers/dwpose.py
@@ -8,7 +8,7 @@ import json
 
 DWPOSE_MODEL_NAME = "yzd-v/DWPose"
 #Trigger startup caching for onnxruntime
-GPU_PROVIDERS = ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "CoreMLExecutionProvider"]
+GPU_PROVIDERS = ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider", "CPUExecutionProvider"]
 def check_ort_gpu():
     try:
         import onnxruntime as ort

--- a/src/custom_controlnet_aux/dwpose/util.py
+++ b/src/custom_controlnet_aux/dwpose/util.py
@@ -436,7 +436,7 @@ def guess_onnx_input_shape_dtype(filename):
 if os.getenv('AUX_ORT_PROVIDERS'):
     ONNX_PROVIDERS = os.getenv('AUX_ORT_PROVIDERS').split(',')
 else:
-    ONNX_PROVIDERS = ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "CPUExecutionProvider"]
+    ONNX_PROVIDERS = ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider", "CPUExecutionProvider"]
 def get_ort_providers() -> List[str]:
     providers = []
     try:

--- a/utils.py
+++ b/utils.py
@@ -46,7 +46,7 @@ else:
     annotator_ckpts_path = str(Path(here, "./ckpts"))
     TEMP_DIR = tempfile.gettempdir()
     USE_SYMLINKS = False
-    ORT_PROVIDERS = ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "CPUExecutionProvider", "CoreMLExecutionProvider"]
+    ORT_PROVIDERS = ["CUDAExecutionProvider", "DirectMLExecutionProvider", "OpenVINOExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider", "CPUExecutionProvider"]
 
 os.environ['AUX_ANNOTATOR_CKPTS_PATH'] = os.getenv('AUX_ANNOTATOR_CKPTS_PATH', annotator_ckpts_path)
 os.environ['AUX_TEMP_DIR'] = os.getenv('AUX_TEMP_DIR', str(TEMP_DIR))


### PR DESCRIPTION
The MIGraphXExecutionProvider is the standard and supported way to accelerate onnx models on AMD hardware from onnxruntime 1.23.
With this pull request I add back this provider