### PR TITLE
Fix DWPose detection by converting RGB to BGR

### DIFF
--- a/src/custom_controlnet_aux/dwpose/wholebody.py
+++ b/src/custom_controlnet_aux/dwpose/wholebody.py
@@ -79,6 +79,10 @@ class Wholebody:
     def __call__(self, oriImg) -> Optional[np.ndarray]:
         #Sacrifice accurate time measurement for compatibility 
         
+        # DWPose models expect BGR input; ComfyUI provides RGB.
+        if oriImg.ndim == 3 and oriImg.shape[2] == 3:
+            oriImg = oriImg[:, :, ::-1].copy()
+
         det_result = None
         
         if self.det is None:


### PR DESCRIPTION
## Problem

`DWPreprocessor` can fail to detect people and output an empty pose image. ComfyUI delivers images as RGB, but the DWPose YOLOX/RTMPose models are trained on BGR (OpenMMLab/OpenCV convention; the yzd-v demos read images with `cv2.imread`). The pipeline never converts, so the detector and pose model see wrong channels.

## Change

Convert RGB -> BGR once at the start of `Wholebody.__call__`, before detection and pose inference. Geometry is untouched, so keypoint coordinates stay valid. Applies to both ONNX and TorchScript backends and matches the existing `open_pose` processor, which already does `oriImg[:, :, ::-1]`.

## Tests

Ran `DWPreprocessor` on images that previously produced a blank pose; people are now detected correctly.